### PR TITLE
feat: update AI provider models and add xAI support with improved CLI UX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,22 @@ install: clean-pyc
 	python3 -m venv $(VENV)
 	# Install in the virtual environment (temporary activation)
 	. $(VENV)/bin/activate && python -m pip install -e ".[dev]"
+	@echo "\n✓ Development environment ready!"
 	@echo "\nVerifying installation:"
-	@echo "Binary location: $(VENV)/bin/aipr"
-	@echo "Python package location: $$($(VENV)/bin/python -c "import aipr; print(aipr.__file__)")"
+	@echo "  Development binary: $(VENV)/bin/aipr"
+	@echo "  Package location: $$($(VENV)/bin/python -c "import aipr; print(aipr.__file__)")"
+	@if command -v aipr >/dev/null 2>&1; then \
+		GLOBAL_AIPR=$$(which aipr); \
+		if [ "$$GLOBAL_AIPR" != "$$(pwd)/$(VENV)/bin/aipr" ]; then \
+			echo "\n⚠️  WARNING: Found aipr installed globally at $$GLOBAL_AIPR"; \
+			echo "   This may conflict with your local development version."; \
+			echo "\n   To use your local version, run: source .venv/bin/activate"; \
+			echo "   Or to remove the global version: pipx uninstall pr-generator-agent"; \
+		fi; \
+	fi
 	@echo "\nNext step:"
-	@echo "To begin development, run: source .venv/bin/activate"
-	@echo "This will activate the virtual environment in your shell"
+	@echo "  Run: source .venv/bin/activate"
+	@echo "  This activates the virtual environment for development"
 
 format:
 	. $(VENV)/bin/activate && python -m black aipr/ tests/

--- a/README.md
+++ b/README.md
@@ -109,19 +109,24 @@ docs: update installation and usage documentation
 
 ## Environment Variables
 
-#### Anthropic (Default)
-- `ANTHROPIC_API_KEY`: Anthropic API key
+The tool automatically detects which provider to use based on available environment variables, with the following priority order:
 
-#### Azure OpenAI
-- `AZURE_API_KEY`: Azure OpenAI API key
-- `AZURE_API_BASE`: Azure endpoint URL
-- `AZURE_API_VERSION`: API version (default: "2024-02-15-preview")
+1. **Azure OpenAI (Default - Highest Priority)**
+   - `AZURE_API_KEY`: Azure OpenAI API key
+   - `AZURE_OPENAI_ENDPOINT`: Azure endpoint URL
+   - `AZURE_API_VERSION`: API version (default: "2024-02-15-preview")
 
-#### OpenAI
-- `OPENAI_API_KEY`: OpenAI API key
+2. **Anthropic**
+   - `ANTHROPIC_API_KEY`: Anthropic API key
 
-#### Google Gemini
-- `GEMINI_API_KEY`: Google Gemini API key
+3. **OpenAI**
+   - `OPENAI_API_KEY`: OpenAI API key
+
+4. **Google Gemini**
+   - `GEMINI_API_KEY`: Google Gemini API key
+
+5. **xAI**
+   - `XAI_API_KEY`: xAI API key for Grok models
 
 ## Usage
 
@@ -187,26 +192,26 @@ Choose from multiple AI providers:
 
 | Provider | Model | Notes |
 |----------|--------|-------|
-| Anthropic | `claude-4` | default (maps to `claude-sonnet-4-20250514`) |
-| | `claude-4.0` | alias for `claude-4` |
-| | `claude-3.5-sonnet` | maps to `claude-3-5-sonnet-20241022` |
-| | `claude-3.5-haiku` | maps to `claude-3-5-haiku-20241022` |
-| | `claude-3-haiku` | maps to `claude-3-haiku-20240307` |
-| | `claude` | alias for `claude-4` |
-| Azure OpenAI | `azure/o1-mini` | |
-| | `azure/gpt-4o` | |
-| | `azure/gpt-4o-mini` | |
-| | `azure/gpt-4` | alias for `azure/gpt-4o` |
-| | `azure` | alias for `azure/gpt-4o-mini` |
-| OpenAI | `gpt-4o` | maps to `gpt-4` |
-| | `gpt-4-turbo` | |
-| | `gpt-3.5-turbo` | |
-| | `gpt4` | alias for `gpt-4` |
-| | `openai` | alias for `gpt-4o` |
-| Google Gemini | `gemini-1.5-pro` | |
-| | `gemini-1.5-flash` | |
-| | `gemini-2.5-pro-experimental` | maps to `gemini-2.5-pro-exp-03-25`, default for Gemini |
-| | `gemini` | alias for `gemini-2.5-pro-experimental` |
+| **Anthropic** | `claude-sonnet-4-5-20250929` | Claude Sonnet 4.5 (default) |
+| | `claude-sonnet-4-20250514` | Claude Sonnet 4 |
+| | `claude-opus-4-1-20250805` | Claude Opus 4.1 |
+| | `claude` | alias for `claude-sonnet-4-5-20250929` |
+| | `opus`, `claude-opus` | aliases for `claude-opus-4-1-20250805` |
+| **Azure OpenAI** | `azure/gpt-5-mini` | default Azure model |
+| | `azure/gpt-4.1-nano` | Lightweight model |
+| | `azure/gpt-5-chat` | Conversational model |
+| | `azure/gpt-5-nano` | Most lightweight model |
+| | `azure` | alias for `azure/gpt-5-mini` |
+| **OpenAI** | `gpt-5` | Latest GPT-5 model (default) |
+| | `gpt-5-mini` | Mid-tier GPT-5 model |
+| | `gpt-5-nano` | Lightweight GPT-5 model |
+| | `openai` | alias for `gpt-5` |
+| **Google Gemini** | `gemini-2.5-flash` | Best price-performance (default) |
+| | `gemini-2.5-pro` | Flagship thinking model with 1M token context |
+| | `gemini-2.5-flash-lite` | Most cost-effective model |
+| | `gemini` | alias for `gemini-2.5-flash` |
+| **xAI** | `grok-code-fast-1` | Specialized for coding tasks |
+| | `grok`, `xai` | aliases for `grok-code-fast-1` |
 
 ## Custom Prompts
 


### PR DESCRIPTION
Closes #43

## Summary
This PR modernizes AI provider support by updating to the latest model versions, adding xAI (Grok) integration, and significantly improving CLI user experience.

## Key Changes

### Provider Model Updates
- **Azure OpenAI**: Default changed to , added GPT-5 series support
- **Anthropic**: Default updated to , added opus aliases
- **OpenAI**: Default updated to , added GPT-5 series support
- **Gemini**: Default updated to , restricted to 2.5 series
- **xAI**: New provider with  model

### GPT-5 Reasoning Model Fixes
- Fixed parameter handling for GPT-5 models (both Azure and OpenAI)
- Use `max_completion_tokens` instead of `max_tokens`
- Remove temperature parameter (uses default 1.0)
- Increased token limit to 8000 for reasoning + output tokens
- Prevents empty responses from reasoning models

### CLI UX Improvements
- `pr` is now the default subcommand (`aipr -m claude` works without explicit `pr`)
- Added `-p/--prompt` flag to global options
- Simplified help text to show only main aliases (azure, claude, gpt-5, gemini, grok)
- Fixed argument parsing order for subcommands

### Development Environment
- Added Makefile warnings for global installation conflicts
- Improved installation output formatting with visual indicators

### Code Quality
- Added strict model validation with clear error messages
- Removed support for legacy models (GPT-4, Claude 3.5, etc.)
- Updated provider priority: Azure > Anthropic > OpenAI > Gemini > xAI
- Added test helper `clear_other_provider_keys()` for isolated provider testing
- All 88 tests passing

## Test Plan
- [x] All existing tests pass (`make test`)
- [x] Verified model switching works: `aipr -m claude`, `aipr -m azure`, `aipr -m gpt-5`
- [x] Verified GPT-5 models produce output (fixed empty response issue)
- [x] Verified default subcommand works (`aipr` without `pr`)
- [x] Verified `-p` flag in help and functionality

## Breaking Changes
- Removed support for legacy models (gpt-4, gpt-4o, claude-3.5-sonnet, etc.)
- Changed Azure default from gpt-5-mini to gpt-5-nano
- Changed Anthropic default from claude-sonnet-4-20250514 to claude-sonnet-4-5-20250929
- Provider priority changed (Azure is now highest priority when configured)

Users need to update to new model names or use simple aliases (azure, claude, gpt-5, gemini, grok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)