### PR TITLE
fix: update default Anthropic models to current non-retired versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,8 +39,8 @@ AIPR is an AI-powered tool that automatically generates comprehensive pull reque
 - **`aipr/prompts/prompts.py`**: Prompt management with PromptManager class, handles built-in and custom XML prompts
 
 ### Provider-Specific Notes
-- **Azure OpenAI**: o1-mini model requires special handling (no temperature parameter, system prompt prepended to user message)
-- **Model Aliases**: "claude" → claude-sonnet-4-20250514, "azure" → gpt-4o-mini, "openai" → gpt-4o, "gemini" → gemini-2.5-pro-experimental
+- **Azure OpenAI / OpenAI**: GPT-5 series and gpt-4.1 models require special handling (use `max_completion_tokens` instead of `max_tokens`, no custom temperature)
+- **Model Aliases**: "claude" → claude-sonnet-4-6, "opus"/"claude-opus" → claude-opus-4-8, "azure" → gpt-5-nano, "openai" → gpt-5, "gemini" → gemini-2.5-flash, "grok"/"xai" → grok-code-fast-1
 
 ### Custom Prompts
 **PR Description Prompts** must be XML files with:

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ aipr commit --from v1.0.0
 
 # Custom usage - Analyze changes against main branch
 # Include: Vulnerability scanning
-# Use: Azure OpenAI o1-mini model
+# Use: Azure OpenAI GPT-5 Mini model
 # Prompt: meta template
 # Output: Verbose
-aipr pr -t main --vulns -p meta -m azure/o1-mini -v
+aipr pr -t main --vulns -p meta -m azure/gpt-5-mini -v
 
 # Inline with merge request creation
 gh pr create -b "$(aipr pr -s)" -t "feat: New Feature"
@@ -192,11 +192,12 @@ Choose from multiple AI providers:
 
 | Provider | Model | Notes |
 |----------|--------|-------|
-| **Anthropic** | `claude-sonnet-4-5-20250929` | Claude Sonnet 4.5 (default) |
-| | `claude-sonnet-4-20250514` | Claude Sonnet 4 |
-| | `claude-opus-4-1-20250805` | Claude Opus 4.1 |
-| | `claude` | alias for `claude-sonnet-4-5-20250929` |
-| | `opus`, `claude-opus` | aliases for `claude-opus-4-1-20250805` |
+| **Anthropic** | `claude-sonnet-4-6` | Claude Sonnet 4.6 (default) |
+| | `claude-opus-4-8` | Claude Opus 4.8 |
+| | `claude-sonnet-4-5-20250929` | Claude Sonnet 4.5 (legacy pin) |
+| | `claude-opus-4-1-20250805` | Claude Opus 4.1 (legacy pin) |
+| | `claude` | alias for `claude-sonnet-4-6` |
+| | `opus`, `claude-opus` | aliases for `claude-opus-4-8` |
 | **Azure OpenAI** | `azure/gpt-5-mini` | default Azure model |
 | | `azure/gpt-4.1-nano` | Lightweight model |
 | | `azure/gpt-5-chat` | Conversational model |

--- a/aipr/main.py
+++ b/aipr/main.py
@@ -32,9 +32,9 @@ def detect_provider_and_model(model: Optional[str]) -> Tuple[str, str]:
     if model:
         # Handle simple aliases first
         if model == "claude":
-            return "anthropic", "claude-sonnet-4-5-20250929"  # New default: Claude Sonnet 4.5
+            return "anthropic", "claude-sonnet-4-6"  # Default: Claude Sonnet 4.6
         if model == "opus" or model == "claude-opus":
-            return "anthropic", "claude-opus-4-1-20250805"
+            return "anthropic", "claude-opus-4-8"  # Claude Opus 4.8
         if model == "azure":
             return "azure", "gpt-5-nano"  # Maps to deployment name in Azure
         if model == "openai":
@@ -86,19 +86,21 @@ def detect_provider_and_model(model: Optional[str]) -> Tuple[str, str]:
                 )
             return "openai", openai_models[model]
 
-        # Handle Anthropic models
+        # Handle Anthropic models - current models plus still-active dated pins
         if model.startswith("claude"):
-            # Direct model names
-            if model == "claude-sonnet-4-5-20250929":
-                return "anthropic", "claude-sonnet-4-5-20250929"
-            if model == "claude-sonnet-4-20250514":
-                return "anthropic", "claude-sonnet-4-20250514"
-            if model == "claude-opus-4-1-20250805":
-                return "anthropic", "claude-opus-4-1-20250805"
-            # If it's a claude model but not supported
-            raise ValueError(
-                f"Unsupported Anthropic model: {model}. Supported: claude-sonnet-4-5-20250929, claude-sonnet-4-20250514, claude-opus-4-1-20250805"
-            )
+            anthropic_models = {
+                "claude-sonnet-4-6": "claude-sonnet-4-6",
+                "claude-opus-4-8": "claude-opus-4-8",
+                # Still-active legacy pins kept for backward compatibility
+                "claude-sonnet-4-5-20250929": "claude-sonnet-4-5-20250929",
+                "claude-opus-4-1-20250805": "claude-opus-4-1-20250805",
+            }
+            if model not in anthropic_models:
+                raise ValueError(
+                    f"Unsupported Anthropic model: {model}. "
+                    f"Supported models: {', '.join(anthropic_models.keys())}"
+                )
+            return "anthropic", anthropic_models[model]
 
         # Handle xAI models
         if model == "grok-code-fast-1":
@@ -109,7 +111,7 @@ def detect_provider_and_model(model: Optional[str]) -> Tuple[str, str]:
     if os.getenv("AZURE_OPENAI_ENDPOINT") and os.getenv("AZURE_API_KEY"):
         return "azure", "gpt-5-nano"  # Default provider and model
     if os.getenv("ANTHROPIC_API_KEY"):
-        return "anthropic", "claude-sonnet-4-5-20250929"  # New default: Claude Sonnet 4.5
+        return "anthropic", "claude-sonnet-4-6"  # Default: Claude Sonnet 4.6
     if os.getenv("OPENAI_API_KEY"):
         return "openai", "gpt-5"
     if os.getenv("GEMINI_API_KEY"):
@@ -450,7 +452,7 @@ def parse_args(args=None):
         epilog=f"""
 recommended models:
   {GREEN}azure{ENDC} (default)                Azure OpenAI GPT-5 Nano
-  {YELLOW}claude{ENDC}                         Anthropic Claude Sonnet 4.5
+  {YELLOW}claude{ENDC}                         Anthropic Claude Sonnet 4.6
   {YELLOW}gpt-5{ENDC}                          OpenAI GPT-5
   {YELLOW}gemini{ENDC}                         Google Gemini 2.5 Flash
   {YELLOW}grok{ENDC}                           xAI Grok Code Fast 1

--- a/docs/adr/001-provider-architecture.md
+++ b/docs/adr/001-provider-architecture.md
@@ -58,10 +58,12 @@ def call_llm(model_name: str, system_prompt: str, user_prompt: str, temperature:
 
 ## Model Aliasing
 To improve user experience, we implement model aliases:
-- `"claude"` → `"claude-3-5-sonnet-20241022"`
-- `"azure"` → `"gpt-4o"`
-- `"openai"` → `"gpt-4o"`
-- `"gemini"` → `"gemini-2.0-flash-exp"`
+- `"claude"` → `"claude-sonnet-4-6"`
+- `"opus"` / `"claude-opus"` → `"claude-opus-4-8"`
+- `"azure"` → `"gpt-5-nano"`
+- `"openai"` → `"gpt-5"`
+- `"gemini"` → `"gemini-2.5-flash"`
+- `"grok"` / `"xai"` → `"grok-code-fast-1"`
 
 ## Success Criteria
 - New providers can be added in < 30 minutes

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -287,7 +287,7 @@ class TestCommitMainIntegration:
         mock_analyzer.get_staged_changes.return_value = ("diff content", {"total": 1})
         mock_analyzer_class.return_value = mock_analyzer
 
-        mock_detect.return_value = ("anthropic", "claude-sonnet-4-20250514")
+        mock_detect.return_value = ("anthropic", "claude-sonnet-4-6")
         mock_generate.return_value = "feat: add new functionality"
 
         # Create args mock
@@ -341,7 +341,7 @@ class TestCommitMainIntegration:
         mock_analyzer.generate_conventional_commit.return_value = "feat: fallback message"
         mock_analyzer_class.return_value = mock_analyzer
 
-        mock_detect.return_value = ("anthropic", "claude-sonnet-4-20250514")
+        mock_detect.return_value = ("anthropic", "claude-sonnet-4-6")
         mock_generate.side_effect = Exception("API Error")
 
         args = MagicMock()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,7 +72,7 @@ def test_detect_provider_and_model_defaults():
     with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=True):
         provider, model = detect_provider_and_model(None)
         assert provider == "anthropic"
-        assert model == "claude-sonnet-4-5-20250929"
+        assert model == "claude-sonnet-4-6"
 
     # Test with OpenAI key
     with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}, clear=True):
@@ -97,9 +97,9 @@ def test_detect_provider_and_model_aliases():
     """Test all documented model aliases"""
     test_cases = [
         # Simple provider aliases
-        ("claude", ("anthropic", "claude-sonnet-4-5-20250929")),
-        ("opus", ("anthropic", "claude-opus-4-1-20250805")),
-        ("claude-opus", ("anthropic", "claude-opus-4-1-20250805")),
+        ("claude", ("anthropic", "claude-sonnet-4-6")),
+        ("opus", ("anthropic", "claude-opus-4-8")),
+        ("claude-opus", ("anthropic", "claude-opus-4-8")),
         ("azure", ("azure", "gpt-5-nano")),  # Updated default
         ("openai", ("openai", "gpt-5")),  # Updated default
         ("gemini", ("gemini", "gemini-2.5-flash")),  # Updated default
@@ -114,9 +114,10 @@ def test_detect_provider_and_model_aliases():
         ("gpt-5", ("openai", "gpt-5")),
         ("gpt-5-mini", ("openai", "gpt-5-mini")),
         ("gpt-5-nano", ("openai", "gpt-5-nano")),
-        # Anthropic models - direct names only
+        # Anthropic models - direct names (current + still-active legacy pins)
+        ("claude-sonnet-4-6", ("anthropic", "claude-sonnet-4-6")),
+        ("claude-opus-4-8", ("anthropic", "claude-opus-4-8")),
         ("claude-sonnet-4-5-20250929", ("anthropic", "claude-sonnet-4-5-20250929")),
-        ("claude-sonnet-4-20250514", ("anthropic", "claude-sonnet-4-20250514")),
         ("claude-opus-4-1-20250805", ("anthropic", "claude-opus-4-1-20250805")),
         # Gemini model aliases - only 2.5 series
         ("gemini-2.5-pro", ("gemini", "gemini-2.5-pro")),
@@ -172,16 +173,21 @@ def test_detect_provider_and_model_gemini():
 def test_detect_provider_and_model_anthropic():
     """Test Anthropic model detection"""
     test_cases = [
-        ("claude", ("anthropic", "claude-sonnet-4-5-20250929")),
-        ("opus", ("anthropic", "claude-opus-4-1-20250805")),
-        ("claude-opus", ("anthropic", "claude-opus-4-1-20250805")),
+        ("claude", ("anthropic", "claude-sonnet-4-6")),
+        ("opus", ("anthropic", "claude-opus-4-8")),
+        ("claude-opus", ("anthropic", "claude-opus-4-8")),
+        ("claude-sonnet-4-6", ("anthropic", "claude-sonnet-4-6")),
+        ("claude-opus-4-8", ("anthropic", "claude-opus-4-8")),
         ("claude-sonnet-4-5-20250929", ("anthropic", "claude-sonnet-4-5-20250929")),
-        ("claude-sonnet-4-20250514", ("anthropic", "claude-sonnet-4-20250514")),
         ("claude-opus-4-1-20250805", ("anthropic", "claude-opus-4-1-20250805")),
     ]
     for input_model, expected in test_cases:
         provider, model = detect_provider_and_model(input_model)
         assert (provider, model) == expected
+
+    # Retired model IDs must now raise rather than silently 404 at the API
+    with pytest.raises(ValueError, match="Unsupported Anthropic model"):
+        detect_provider_and_model("claude-sonnet-4-20250514")
 
 
 # Trivy Scanning Tests
@@ -1217,7 +1223,7 @@ class TestCommitRangeFunctionality:
         mock_repo = MagicMock()
         mock_repo_class.return_value = mock_repo
         mock_determine_mode.return_value = "range"
-        mock_detect.return_value = ("anthropic", "claude-sonnet-4-5-20250929")
+        mock_detect.return_value = ("anthropic", "claude-sonnet-4-6")
         mock_get_diff.return_value = ("commit range diff content", {"total": 1, "files": []})
         mock_generate.return_value = "feat: add new feature from commit range"
 
@@ -1261,7 +1267,7 @@ class TestCommitRangeFunctionality:
 
         # Setup mocks
         mock_determine_mode.return_value = "range"
-        mock_detect.return_value = ("anthropic", "claude-sonnet-4-5-20250929")
+        mock_detect.return_value = ("anthropic", "claude-sonnet-4-6")
         mock_get_diff.return_value = ("commit range diff content", {"files": [], "total": 0})
         mock_generate.return_value = "PR description from commit range"
 


### PR DESCRIPTION
## Summary

The `claude` alias (and the `ANTHROPIC_API_KEY` provider default) resolved to older Anthropic models, and the supported-model list still accepted `claude-sonnet-4-20250514`, which Anthropic **retired on 2026-06-15**. Any install pinned to that model now gets an HTTP 404 from the API, which surfaces as garbage output (e.g. `fix: fix issues in 5 files`) instead of a real description/commit message. The `opus` alias also pointed at `claude-opus-4-1-20250805`, which is deprecated and retires 2026-08-05.

This updates the defaults to current, actively-served models and removes the retired one so failures are explicit rather than 404-at-runtime.

## Changes

- **`claude` alias + `ANTHROPIC_API_KEY` default:** `claude-sonnet-4-5-20250929` → `claude-sonnet-4-6`
- **`opus` / `claude-opus` alias:** `claude-opus-4-1-20250805` → `claude-opus-4-8`
- **Removed** retired `claude-sonnet-4-20250514` from the supported list (now raises a clear `ValueError` instead of 404-ing at the API)
- **Kept** `claude-sonnet-4-5-20250929` and `claude-opus-4-1-20250805` as still-active legacy pins for backward compatibility
- Refactored Anthropic model handling into a dict, matching the existing azure/openai/gemini style
- Fixed a stale README example that used the unsupported `azure/o1-mini` → `azure/gpt-5-mini`
- Refreshed model references in `README.md` and `CLAUDE.md`

## Technical Details

- Model resolution lives in `detect_provider_and_model()` (`aipr/main.py`). The simple aliases are resolved first, then explicit model IDs are validated against the `anthropic_models` dict; unknown `claude-*` IDs raise `ValueError` with the supported list.
- Tests updated in `tests/test_main.py` and `tests/test_commit.py`, including a new assertion that the retired `claude-sonnet-4-20250514` now raises rather than resolving.
- `make check` (black, isort, flake8, pytest) passes — 88 tested, all green.