### PR TITLE
fix(commit): normalize AI-generated commit message output

### DIFF
--- a/aipr/commit.py
+++ b/aipr/commit.py
@@ -6,6 +6,114 @@ from typing import Dict, Optional, Tuple
 
 import git
 
+# Maximum length for a conventional commit subject line.
+# Matches the "under 72 characters" guidance in aipr/prompts/commit.xml.
+MAX_SUBJECT_LENGTH = 72
+
+# Matches a conventional commit subject: type, optional scope, optional "!",
+# then ": " (e.g. "feat: ...", "fix(core): ...", "refactor(api)!: ...").
+_COMMIT_SUBJECT_RE = re.compile(
+    r"^(?:feat|fix|docs|style|refactor|perf|test|build|ci|chore)" r"(?:\([^)]*\))?!?:\s",
+    re.IGNORECASE,
+)
+
+
+def _is_fence(line: str) -> bool:
+    """Return True if a line is a markdown code fence marker (``` or ```lang)."""
+    return line.strip().startswith("```")
+
+
+def _split_subject(subject: str, limit: int) -> Tuple[str, str]:
+    """Split an over-long subject at the last word boundary at or before ``limit``.
+
+    Args:
+        subject: The subject line to split.
+        limit: Maximum length for the head (subject) portion.
+
+    Returns:
+        A ``(head, tail)`` tuple. If no suitable word boundary exists at or
+        before ``limit`` (e.g. a single very long token), the subject is
+        returned unchanged with an empty tail.
+    """
+    if len(subject) <= limit:
+        return subject, ""
+    break_at = subject.rfind(" ", 0, limit + 1)
+    if break_at <= 0:
+        return subject, ""
+    return subject[:break_at].rstrip(), subject[break_at:].strip()
+
+
+def normalize_commit_message(message: str) -> str:
+    """Normalize a raw AI-generated commit message into a well-formed commit.
+
+    Model output cannot be trusted to match the repository's conventions, so
+    this enforces them deterministically after generation.
+
+    Guarantees:
+    - No surrounding markdown code fences or leading explanatory prose.
+    - A single-line subject separated from any body by exactly one blank line.
+    - A subject no longer than ``MAX_SUBJECT_LENGTH``; overflow (when the model
+      returns a run-on subject with no body) is wrapped into the body at a word
+      boundary rather than shipped as a single long line.
+    - No trailing period on the subject line.
+
+    Args:
+        message: The raw text returned by the AI provider.
+
+    Returns:
+        A cleaned commit message ready to hand to ``git commit``.
+    """
+    if not message or not message.strip():
+        return ""
+
+    lines = message.strip().splitlines()
+
+    # 1. Strip leading/trailing markdown code fences the model may wrap around
+    #    the message (handles ```, ```bash, and a fenced-then-preamble mix).
+    while lines and _is_fence(lines[0]):
+        lines = lines[1:]
+    while lines and _is_fence(lines[-1]):
+        lines = lines[:-1]
+
+    # 2. Drop any leading preamble before the real conventional-commit line
+    #    (e.g. "Here is your commit message:").
+    subject_idx = next(
+        (i for i, line in enumerate(lines) if _COMMIT_SUBJECT_RE.match(line.strip())),
+        None,
+    )
+    if subject_idx:  # truthy => a subject was found at index > 0
+        lines = lines[subject_idx:]
+
+    # 3. Separate the subject (first non-empty line) from the body.
+    while lines and not lines[0].strip():
+        lines = lines[1:]
+    if not lines:
+        return ""
+
+    subject = lines[0].strip()
+    body_lines = lines[1:]
+
+    # 4. Strip a single trailing period from the subject (but keep an ellipsis).
+    if subject.endswith(".") and not subject.endswith(".."):
+        subject = subject[:-1].rstrip()
+
+    # Collapse blank lines that lead the body.
+    while body_lines and not body_lines[0].strip():
+        body_lines = body_lines[1:]
+    body = "\n".join(body_lines).strip("\n")
+
+    # 5. A run-on subject with no body is the failure mode we most want to
+    #    prevent: wrap the overflow into the body instead of shipping it.
+    if len(subject) > MAX_SUBJECT_LENGTH and not body:
+        head, tail = _split_subject(subject, MAX_SUBJECT_LENGTH)
+        if tail:
+            subject = head
+            body = tail
+
+    if body:
+        return f"{subject}\n\n{body}"
+    return subject
+
 
 class CommitAnalyzer:
     """Analyzes git changes to generate conventional commit messages."""

--- a/aipr/main.py
+++ b/aipr/main.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 import git
 import tiktoken
 
-from .commit import CommitAnalyzer
+from .commit import CommitAnalyzer, normalize_commit_message
 from .prompts import InvalidPromptError, PromptManager
 from .providers import (
     generate_with_anthropic,
@@ -1133,8 +1133,9 @@ def handle_commit_command(args):
                 changes, file_summary, provider, model, args.verbose, context
             )
 
-            # Clean up the response (remove any extra whitespace/newlines)
-            commit_message = commit_message.strip()
+            # Normalize the response into a well-formed conventional commit
+            # (single-line subject, blank-line body, length-bounded subject).
+            commit_message = normalize_commit_message(commit_message)
 
             if args.verbose:
                 print("\nGenerated commit message:", file=sys.stderr)

--- a/aipr/prompts/prompts.py
+++ b/aipr/prompts/prompts.py
@@ -258,5 +258,13 @@ class PromptManager:
             "- type: feat/fix/docs/test/build/ci/chore/refactor/style/perf\n"
             "- scope: optional, derived from the main area of change\n"
             "- description: imperative mood, specific to the implementation\n\n"
+            "SUBJECT LINE RULES (STRICT):\n"
+            "- The subject is a SINGLE line: 'type(scope): description'\n"
+            "- Keep the subject under 72 characters - never emit a run-on subject\n"
+            "- Lowercase after the colon, imperative mood, no trailing period\n\n"
+            "OPTIONAL BODY:\n"
+            "- For substantial changes, add a body AFTER one blank line\n"
+            "- Put extra detail in the body instead of lengthening the subject\n"
+            "- Keep each body line under 80 characters\n\n"
             "RESPOND WITH ONLY THE COMMIT MESSAGE - NO EXPLANATIONS OR ADDITIONAL TEXT."
         )

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -10,7 +10,7 @@ import pytest
 from git import Repo
 from git.exc import InvalidGitRepositoryError
 
-from aipr.commit import CommitAnalyzer
+from aipr.commit import MAX_SUBJECT_LENGTH, CommitAnalyzer, normalize_commit_message
 from aipr.main import handle_commit_command
 
 
@@ -429,6 +429,97 @@ class TestCommitPromptGeneration:
 
         assert "conventional commit" in system_prompt.lower()
         assert "type(scope): description" in system_prompt
+
+
+class TestNormalizeCommitMessage:
+    """Test normalization of raw AI-generated commit messages."""
+
+    def test_clean_single_line_passthrough(self):
+        """A well-formed single-line subject is returned unchanged."""
+        assert (
+            normalize_commit_message("feat: add new functionality") == "feat: add new functionality"
+        )
+
+    def test_empty_input(self):
+        """Empty or whitespace-only input returns an empty string."""
+        assert normalize_commit_message("") == ""
+        assert normalize_commit_message("   \n  ") == ""
+
+    def test_strips_surrounding_whitespace(self):
+        """Leading/trailing whitespace is trimmed."""
+        assert normalize_commit_message("\n  fix: correct bug  \n") == "fix: correct bug"
+
+    def test_strips_plain_code_fence(self):
+        """A message wrapped in a bare ``` fence is unwrapped."""
+        raw = "```\nfeat: add feature\n```"
+        assert normalize_commit_message(raw) == "feat: add feature"
+
+    def test_strips_language_code_fence(self):
+        """A ```bash fenced message is unwrapped."""
+        raw = "```bash\nfix(api): handle null user\n```"
+        assert normalize_commit_message(raw) == "fix(api): handle null user"
+
+    def test_strips_leading_preamble(self):
+        """Explanatory prose before the commit line is dropped."""
+        raw = "Here is your commit message:\nfeat: add parser"
+        assert normalize_commit_message(raw) == "feat: add parser"
+
+    def test_preamble_and_fence_combination(self):
+        """A preamble plus a trailing fence are both removed."""
+        raw = "Sure! Here you go:\n```\nfeat: add thing\n```"
+        assert normalize_commit_message(raw) == "feat: add thing"
+
+    def test_inserts_blank_line_between_subject_and_body(self):
+        """A body glued directly to the subject gets a blank-line separator."""
+        raw = "feat: add x\nExtra detail about the change"
+        assert normalize_commit_message(raw) == "feat: add x\n\nExtra detail about the change"
+
+    def test_collapses_extra_blank_lines(self):
+        """Multiple blank lines between subject and body collapse to one."""
+        raw = "feat: add x\n\n\n\nbody detail"
+        assert normalize_commit_message(raw) == "feat: add x\n\nbody detail"
+
+    def test_strips_trailing_period_from_subject(self):
+        """A single trailing period on the subject is removed."""
+        assert normalize_commit_message("fix: correct the thing.") == "fix: correct the thing"
+
+    def test_preserves_ellipsis(self):
+        """An ellipsis on the subject is preserved (not stripped to '..')."""
+        assert normalize_commit_message("chore: work in progress...") == (
+            "chore: work in progress..."
+        )
+
+    def test_wraps_run_on_subject_with_no_body(self):
+        """A long run-on subject with no body is wrapped into subject + body."""
+        run_on = (
+            "feat: implement conventional commit generation with detailed "
+            "analysis of staged changes and automatic type detection and scope"
+        )
+        assert len(run_on) > MAX_SUBJECT_LENGTH
+
+        result = normalize_commit_message(run_on)
+        subject = result.split("\n\n", 1)[0]
+
+        # Subject is now within the limit and a body was created.
+        assert len(subject) <= MAX_SUBJECT_LENGTH
+        assert "\n\n" in result
+        # No content is lost: subject head + body reconstruct the original.
+        head, body = result.split("\n\n", 1)
+        assert f"{head} {body}" == run_on
+
+    def test_does_not_wrap_subject_when_body_present(self):
+        """An over-long subject with an explicit body is left intact."""
+        long_subject = "feat: " + "word " * 30  # well over the limit
+        raw = f"{long_subject.strip()}\n\nexisting body"
+        result = normalize_commit_message(raw)
+        # Subject preserved as-is (we don't shuffle content into an existing body).
+        assert result.split("\n\n", 1)[0] == long_subject.strip()
+        assert result.endswith("existing body")
+
+    def test_unbreakable_long_token_left_unchanged(self):
+        """A subject with no whitespace to break on is returned as-is."""
+        raw = "feat:" + "a" * 100
+        assert normalize_commit_message(raw) == raw
 
 
 # Fixtures


### PR DESCRIPTION
## Summary

`aipr commit` printed the model's raw output verbatim (only `.strip()`-ed), so a malformed response — a ~180-char run-on subject with no body — shipped as-is, violating the conventional-commit subject convention. The model was pushed toward that shape by a prompt conflict: the commit **system prompt** implied a single-line `type(scope): description` with no length cap or body, while the real rules lived only in the **user prompt** (`commit.xml`).

This PR adds a deterministic normalization safety net and realigns the system prompt so well-formed output is produced up front.

## Changes

- **`aipr/commit.py`** — add `normalize_commit_message()` (plus `_is_fence`/`_split_subject` helpers and `MAX_SUBJECT_LENGTH = 72`). It strips code fences and leading preambles, guarantees a single-line subject separated from any body by one blank line, drops a trailing period (preserving ellipses), and wraps an over-length run-on subject (no body) into subject + body at a word boundary.
- **`aipr/main.py`** — route the AI-generated commit message through `normalize_commit_message()` instead of a bare `.strip()`.
- **`aipr/prompts/prompts.py`** — add explicit STRICT subject-line rules (single line, under 72 chars, no trailing period) and an optional-body section to the commit system prompt, removing the single-line implication so models stop emitting run-on subjects.
- **`tests/test_commit.py`** — 13 new tests covering fences, preambles, blank-line insertion, run-on wrapping, trailing-period/ellipsis handling, and unbreakable tokens.

## Technical Details

- The subject cap of **72** matches the existing `commit.xml` guidance to avoid introducing a conflicting limit.
- Run-on wrapping only triggers when the subject exceeds the limit **and** there is no body — the precise reported failure mode — and never merges content into an existing body.
- Normalization is deterministic: identical model output yields identical formatting.
- Validated with `make check`: black, isort, flake8, and **102 tests** pass.
