### PR TITLE
feat(cli): add --version flag

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
 
   # Security checks
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.9.4
     hooks:
       - id: bandit
         args: ['-ll', '--skip', 'B101,B601,B314']  # Skip XML parsing warnings

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ aipr pr [options]  # or just 'aipr' for backward compatibility
 - `-d, --debug`: Preview prompts without API calls
 - `-s, --silent`: Output only the description
 - `-m, --model`: Specify AI model to use
+- `-V, --version`: Show the installed aipr version and exit
 
 The tool intelligently detects changes by:
 1. Using staged/unstaged changes if present

--- a/aipr/main.py
+++ b/aipr/main.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 import git
 import tiktoken
 
+from . import __version__
 from .commit import CommitAnalyzer, normalize_commit_message
 from .prompts import InvalidPromptError, PromptManager
 from .providers import (
@@ -463,6 +464,13 @@ prompt templates (use with -p flag):
     )
 
     # Global options
+    parser.add_argument(
+        "-V",
+        "--version",
+        action="version",
+        version=f"aipr {__version__}",
+        help="Show the installed aipr version and exit",
+    )
     parser.add_argument("-s", "--silent", action="store_true", help="Silent mode")
     parser.add_argument(
         "-d",
@@ -574,14 +582,21 @@ prompt templates (use with -p flag):
     # Check if args look like old-style (no subcommand) before parsing
     is_old_style = True
     if args is not None:
-        # If first arg is a known subcommand or help, it's new style
-        if len(args) > 0 and args[0] in ["pr", "commit", "-h", "--help"]:
+        # If first arg is a known subcommand, help, or version, it's new style
+        if len(args) > 0 and args[0] in ["pr", "commit", "-h", "--help", "-V", "--version"]:
             is_old_style = False
     else:
         # Check sys.argv for subcommands
         import sys
 
-        if len(sys.argv) > 1 and sys.argv[1] in ["pr", "commit", "-h", "--help"]:
+        if len(sys.argv) > 1 and sys.argv[1] in [
+            "pr",
+            "commit",
+            "-h",
+            "--help",
+            "-V",
+            "--version",
+        ]:
             is_old_style = False
 
     if is_old_style:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1376,6 +1376,16 @@ class TestCommitRangeFunctionality:
         assert args.to_commit is None
         assert args.silent is True
 
+    def test_version_flag(self, capsys):
+        """Test that --version prints the package version and exits."""
+        from aipr import __version__
+        from aipr.main import parse_args
+
+        with pytest.raises(SystemExit) as exc_info:
+            parse_args(["--version"])
+        assert exc_info.value.code == 0
+        assert f"aipr {__version__}" in capsys.readouterr().out
+
     def test_commit_range_help_text_includes_range_info(self):
         """Test that help text includes information about commit range functionality."""
         from aipr.main import parse_args


### PR DESCRIPTION
- Concise summary
  - Introduced a new CLI flag to display the installed aipr version (--version / -V) and exit.
  - Updated CLI parsing to recognize version flag as a valid command style.
  - Added unit test to verify version output and exit status.
  - Updated documentation to describe the new version flag.
  - Bumped the Bandit security scanner in pre-commit and configured it to skip specific checks to reduce noise.

- Key modifications and their purpose
  - aipr/main.py
    - Import __version__ and expose a versioned CLI output via -V/--version using action="version" with the formatted string "aipr {__version__}".
    - Extend new-style command detection to include -V/--version so that the version flag is treated consistently with other subcommands.
  - README.md
    - Add the new -V, --version option description to the user-facing help/usage section.
  - tests/test_main.py
    - Add test_version_flag to verify that parse_args(["--version"]) raises SystemExit with code 0 and prints "aipr {__version__}".
  - .pre-commit-config.yaml
    - Bump Bandit from rev 1.7.5 to 1.9.4.
    - Configure Bandit hook to skip checks B101, B601, B314 to reduce false positives for XML parsing warnings.
  
- Notable technical details
  - Version display uses the module’s __version__ attribute to ensure the printed version matches the installed package version.
  - Old-style vs new-style argument detection now includes -V/--version in the known new-style command set, both for direct args and sys.argv inspection.
  - Test leverages pytest to ensure the CLI behavior matches expected version output and exit status.

- Security impact analysis
  - Security tooling: Upgrading Bandit to 1.9.4 improves vulnerability detection coverage and fixes, potentially catching newer issue patterns.
  - Noise reduction: Skipping B101, B601, B314 reduces noise from certain findings (e.g., assert usage, some OS-level checks, or XML parsing warnings) but may hide related issues; no new vulnerabilities are introduced by the changes themselves.
  - The code changes for the version flag do not introduce security risks; they simply provide a safe mechanism to query the installed version.

- Notable fixed vulnerabilities
  - None reported in this diff; changes mainly adjust tooling configuration and CLI behavior.

- Last specific change or security finding discussed
  - test_version_flag added.
