### PR TITLE
feat: update default Anthropic model to Claude Sonnet 5

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
 
   # Security checks
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.9.4
     hooks:
       - id: bandit
         args: ['-ll', '--skip', 'B101,B601,B314']  # Skip XML parsing warnings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ AIPR is an AI-powered tool that automatically generates comprehensive pull reque
 
 ### Provider-Specific Notes
 - **Azure OpenAI / OpenAI**: GPT-5 series and gpt-4.1 models require special handling (use `max_completion_tokens` instead of `max_tokens`, no custom temperature)
-- **Model Aliases**: "claude" → claude-sonnet-4-6, "opus"/"claude-opus" → claude-opus-4-8, "azure" → gpt-5-nano, "openai" → gpt-5, "gemini" → gemini-2.5-flash, "grok"/"xai" → grok-code-fast-1
+- **Model Aliases**: "claude"/"sonnet" → claude-sonnet-5, "opus"/"claude-opus" → claude-opus-4-8, "azure" → gpt-5-nano, "openai" → gpt-5, "gemini" → gemini-2.5-flash, "grok"/"xai" → grok-code-fast-1
 
 ### Custom Prompts
 **PR Description Prompts** must be XML files with:

--- a/README.md
+++ b/README.md
@@ -192,11 +192,12 @@ Choose from multiple AI providers:
 
 | Provider | Model | Notes |
 |----------|--------|-------|
-| **Anthropic** | `claude-sonnet-4-6` | Claude Sonnet 4.6 (default) |
+| **Anthropic** | `claude-sonnet-5` | Claude Sonnet 5 (default) |
 | | `claude-opus-4-8` | Claude Opus 4.8 |
+| | `claude-sonnet-4-6` | Claude Sonnet 4.6 (previous generation) |
 | | `claude-sonnet-4-5-20250929` | Claude Sonnet 4.5 (legacy pin) |
 | | `claude-opus-4-1-20250805` | Claude Opus 4.1 (legacy pin) |
-| | `claude` | alias for `claude-sonnet-4-6` |
+| | `claude`, `sonnet` | aliases for `claude-sonnet-5` |
 | | `opus`, `claude-opus` | aliases for `claude-opus-4-8` |
 | **Azure OpenAI** | `azure/gpt-5-mini` | default Azure model |
 | | `azure/gpt-4.1-nano` | Lightweight model |

--- a/aipr/main.py
+++ b/aipr/main.py
@@ -31,8 +31,8 @@ def detect_provider_and_model(model: Optional[str]) -> Tuple[str, str]:
     """Detect which provider and model to use based on environment and args."""
     if model:
         # Handle simple aliases first
-        if model == "claude":
-            return "anthropic", "claude-sonnet-4-6"  # Default: Claude Sonnet 4.6
+        if model == "claude" or model == "sonnet":
+            return "anthropic", "claude-sonnet-5"  # Default: Claude Sonnet 5
         if model == "opus" or model == "claude-opus":
             return "anthropic", "claude-opus-4-8"  # Claude Opus 4.8
         if model == "azure":
@@ -89,9 +89,10 @@ def detect_provider_and_model(model: Optional[str]) -> Tuple[str, str]:
         # Handle Anthropic models - current models plus still-active dated pins
         if model.startswith("claude"):
             anthropic_models = {
-                "claude-sonnet-4-6": "claude-sonnet-4-6",
+                "claude-sonnet-5": "claude-sonnet-5",
                 "claude-opus-4-8": "claude-opus-4-8",
-                # Still-active legacy pins kept for backward compatibility
+                # Still-active previous generation and legacy pins
+                "claude-sonnet-4-6": "claude-sonnet-4-6",
                 "claude-sonnet-4-5-20250929": "claude-sonnet-4-5-20250929",
                 "claude-opus-4-1-20250805": "claude-opus-4-1-20250805",
             }
@@ -111,7 +112,7 @@ def detect_provider_and_model(model: Optional[str]) -> Tuple[str, str]:
     if os.getenv("AZURE_OPENAI_ENDPOINT") and os.getenv("AZURE_API_KEY"):
         return "azure", "gpt-5-nano"  # Default provider and model
     if os.getenv("ANTHROPIC_API_KEY"):
-        return "anthropic", "claude-sonnet-4-6"  # Default: Claude Sonnet 4.6
+        return "anthropic", "claude-sonnet-5"  # Default: Claude Sonnet 5
     if os.getenv("OPENAI_API_KEY"):
         return "openai", "gpt-5"
     if os.getenv("GEMINI_API_KEY"):
@@ -452,7 +453,7 @@ def parse_args(args=None):
         epilog=f"""
 recommended models:
   {GREEN}azure{ENDC} (default)                Azure OpenAI GPT-5 Nano
-  {YELLOW}claude{ENDC}                         Anthropic Claude Sonnet 4.6
+  {YELLOW}claude{ENDC}                         Anthropic Claude Sonnet 5
   {YELLOW}gpt-5{ENDC}                          OpenAI GPT-5
   {YELLOW}gemini{ENDC}                         Google Gemini 2.5 Flash
   {YELLOW}grok{ENDC}                           xAI Grok Code Fast 1

--- a/aipr/providers.py
+++ b/aipr/providers.py
@@ -6,6 +6,19 @@ import anthropic
 from openai import AzureOpenAI, OpenAI
 
 
+def _anthropic_extra_params(model: str) -> Dict[str, Any]:
+    """Return per-model request parameters for Anthropic models.
+
+    Claude Sonnet 5 and Opus 4.8 reject non-default sampling parameters
+    (temperature returns a 400). Sonnet 5 also runs adaptive thinking by
+    default, which spends the output-token budget on reasoning - disable it
+    since description generation needs the full budget for visible output.
+    """
+    if model.startswith(("claude-sonnet-5", "claude-opus-4-8", "claude-opus-4-7")):
+        return {"thinking": {"type": "disabled"}}
+    return {"temperature": 0.2}
+
+
 def generate_with_anthropic(
     diff: str,
     vuln_data: Optional[Dict[str, Any]],
@@ -18,13 +31,14 @@ def generate_with_anthropic(
         print("\nInitializing Anthropic client...")
 
     client = anthropic.Anthropic(api_key=os.getenv("ANTHROPIC_API_KEY"))
+    extra_params = _anthropic_extra_params(model)
 
     if verbose:
         print("\nSending request to Anthropic API:")
         print(f"  Model: {model}")
         print(
             "  Parameters:",
-            json.dumps({"max_tokens": 1000, "temperature": 0.2}, indent=2),
+            json.dumps({"max_tokens": 1000, **extra_params}, indent=2),
         )
         print("\nRequest Messages:")
         print("\nSYSTEM MESSAGE:")
@@ -40,9 +54,9 @@ def generate_with_anthropic(
         response = client.messages.create(
             model=model,
             max_tokens=1000,
-            temperature=0.2,
             system=system_prompt,
             messages=[{"role": "user", "content": diff}],
+            **extra_params,
         )
         if verbose:
             print("\nRaw API Response:")

--- a/docs/adr/001-provider-architecture.md
+++ b/docs/adr/001-provider-architecture.md
@@ -58,7 +58,7 @@ def call_llm(model_name: str, system_prompt: str, user_prompt: str, temperature:
 
 ## Model Aliasing
 To improve user experience, we implement model aliases:
-- `"claude"` → `"claude-sonnet-4-6"`
+- `"claude"` / `"sonnet"` → `"claude-sonnet-5"`
 - `"opus"` / `"claude-opus"` → `"claude-opus-4-8"`
 - `"azure"` → `"gpt-5-nano"`
 - `"openai"` → `"gpt-5"`

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -72,7 +72,7 @@ def test_detect_provider_and_model_defaults():
     with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "test-key"}, clear=True):
         provider, model = detect_provider_and_model(None)
         assert provider == "anthropic"
-        assert model == "claude-sonnet-4-6"
+        assert model == "claude-sonnet-5"
 
     # Test with OpenAI key
     with patch.dict("os.environ", {"OPENAI_API_KEY": "test-key"}, clear=True):
@@ -97,7 +97,8 @@ def test_detect_provider_and_model_aliases():
     """Test all documented model aliases"""
     test_cases = [
         # Simple provider aliases
-        ("claude", ("anthropic", "claude-sonnet-4-6")),
+        ("claude", ("anthropic", "claude-sonnet-5")),
+        ("sonnet", ("anthropic", "claude-sonnet-5")),
         ("opus", ("anthropic", "claude-opus-4-8")),
         ("claude-opus", ("anthropic", "claude-opus-4-8")),
         ("azure", ("azure", "gpt-5-nano")),  # Updated default
@@ -115,6 +116,7 @@ def test_detect_provider_and_model_aliases():
         ("gpt-5-mini", ("openai", "gpt-5-mini")),
         ("gpt-5-nano", ("openai", "gpt-5-nano")),
         # Anthropic models - direct names (current + still-active legacy pins)
+        ("claude-sonnet-5", ("anthropic", "claude-sonnet-5")),
         ("claude-sonnet-4-6", ("anthropic", "claude-sonnet-4-6")),
         ("claude-opus-4-8", ("anthropic", "claude-opus-4-8")),
         ("claude-sonnet-4-5-20250929", ("anthropic", "claude-sonnet-4-5-20250929")),
@@ -173,9 +175,11 @@ def test_detect_provider_and_model_gemini():
 def test_detect_provider_and_model_anthropic():
     """Test Anthropic model detection"""
     test_cases = [
-        ("claude", ("anthropic", "claude-sonnet-4-6")),
+        ("claude", ("anthropic", "claude-sonnet-5")),
+        ("sonnet", ("anthropic", "claude-sonnet-5")),
         ("opus", ("anthropic", "claude-opus-4-8")),
         ("claude-opus", ("anthropic", "claude-opus-4-8")),
+        ("claude-sonnet-5", ("anthropic", "claude-sonnet-5")),
         ("claude-sonnet-4-6", ("anthropic", "claude-sonnet-4-6")),
         ("claude-opus-4-8", ("anthropic", "claude-opus-4-8")),
         ("claude-sonnet-4-5-20250929", ("anthropic", "claude-sonnet-4-5-20250929")),
@@ -1419,3 +1423,30 @@ class TestCommitRangeFunctionality:
                             "Invalid commit reference: abc123" in str(call) for call in print_calls
                         )
                         mock_exit.assert_called_with(1)
+
+
+class TestAnthropicRequestParams:
+    """Per-model Anthropic request parameter selection."""
+
+    def test_sonnet_5_omits_temperature_and_disables_thinking(self):
+        """Sonnet 5 rejects temperature and needs thinking disabled."""
+        from aipr.providers import _anthropic_extra_params
+
+        params = _anthropic_extra_params("claude-sonnet-5")
+        assert "temperature" not in params
+        assert params["thinking"] == {"type": "disabled"}
+
+    def test_opus_4_8_omits_temperature(self):
+        """Opus 4.8 rejects non-default sampling parameters."""
+        from aipr.providers import _anthropic_extra_params
+
+        params = _anthropic_extra_params("claude-opus-4-8")
+        assert "temperature" not in params
+
+    def test_legacy_models_keep_temperature(self):
+        """Older Anthropic models keep the low-temperature setting."""
+        from aipr.providers import _anthropic_extra_params
+
+        for model in ("claude-sonnet-4-6", "claude-sonnet-4-5-20250929"):
+            params = _anthropic_extra_params(model)
+            assert params == {"temperature": 0.2}


### PR DESCRIPTION
Summary:
- Update default Anthropic model and aliases to Claude Sonnet 5, expand alias handling, introduce per-model request parameter logic for Anthropic models, and align tests and docs accordingly. Also upgrade the security checks pre-commit bandit configuration.

Key modifications and their purpose:
- aipr/main.py
  - Change: Treat "claude" and "sonnet" as aliases for claude-sonnet-5 (default Anthropic model).
  - Change: Extend Anthropic model mapping to include "claude-sonnet-5" and retain legacy pins like "claude-sonnet-4-6" for backward compatibility.
  - Change: Update default provider/model detection to use claude-sonnet-5 when ANTHROPIC_API_KEY is set.
  - Purpose: Ensure current default is Claude Sonnet 5 and support new alias semantics across the codebase and user-facing docs/tests.
- aipr/providers.py
  - New function: _anthropic_extra_params(model: str) -> Dict[str, Any]
    - Logic: For models starting with claude-sonnet-5, claude-opus-4-8, or claude-opus-4-7, disable thinking; otherwise provide temperature: 0.2.
  - generate_with_anthropic changes:
    - Use extra_params instead of a hardcoded temperature; pass extra_params into the API call.
    - Print and log the per-model parameters (max_tokens remains 1000; additional per-model params applied).
  - Purpose: Fine-tune per-model request behavior for Anthropic models to accommodate model-specific constraints and usage patterns, while preserving a safe default temperature for older/pinned models.
- Documentation and UI/tests updates
  - CLAUDE.md, ADR doc (docs/adr/001-provider-architecture.md), and README.md
    - Update model alias mappings and default model references to reflect claude-sonnet-5 and aliases ("claude"/"sonnet" → claude-sonnet-5).
    - Align embedded default/model notes with the new default.
  - Tests in tests/test_main.py
    - Default test updated to expect claude-sonnet-5.
    - Expanded test cases to cover new aliases ("sonnet" → claude-sonnet-5) and current alias behavior.
- Pre-commit security checks
  - .pre-commit-config.yaml: Bump Bandit to rev 1.9.4 and add skip list for B101,B601,B314.
  - Purpose: Update security checks to a newer Bandit version and reduce noise by skipping certain warnings during pre-commit checks.

Notable technical details:
- Per-model param handling for Anthropic:
  - claude-sonnet-5, claude-opus-4-8, claude-opus-4-7: thinking disabled.
  - All other models: temperature set to 0.2.
- Integration points:
  - extra_params is computed once per call and merged into both the log output and the API request payload.
  - Backward-compatible pins remain accessible for existing users via the aliasing and explicit model checks.
- Documentation and tests now reflect Claude Sonnet 5 as the default and the expanded alias set.

Security impact analysis:
- Upgraded pre-commit security checks:
  - Bandit updated to 1.9.4 to improve vulnerability scanning coverage; certain warnings are skipped (B101, B601, B314) to reduce noise for known patterns or non-critical contexts.
  - Impact: Increases maintainability of security checks while potentially reducing coverage for the skipped categories; critical issues should still be detected by other controls.
- Anthropic parameter handling changes:
  - Introducing per-model parameter controls (disabling thinking for Sonnet 5 and Opus 4-8) reduces unwanted model behavior that could affect output quality or resource usage, indirectly limiting potential exposure from misconfigured prompts.
  - Legacy pins retained for compatibility, ensuring no sudden exposure due to alias changes, but with updated default behavior for new users.
- Documentation and tests:
  - Updated to reflect new default and aliasing, reducing user confusion and potential misconfiguration that could lead to insecure usage patterns.

Test artifacts and verifications:
- Tests updated to reflect new default and alias behavior.
- New tests in TestAnthropicRequestParams validate per-model parameter logic:
  - Sonnet 5 omits temperature and disables thinking.
  - Opus 4-8 omits temperature.
  - Legacy models retain temperature=0.2.

TestAnthropicRequestParams: added tests for per-model params.

---
**Merge note:** this PR and #63 both touch `generate_with_anthropic` in `aipr/providers.py`; whichever merges second needs a trivial conflict resolution. The bandit pre-commit rev bump duplicates the fix already on the #62 branch.
