### PR TITLE
fix(version): fall back to package metadata for installed packages

### DIFF
--- a/aipr/__init__.py
+++ b/aipr/__init__.py
@@ -3,15 +3,27 @@ AIPR - AI-powered Merge Request Description Generator
 """
 
 import tomllib
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _package_version
 from pathlib import Path
 
 
 def get_version():
+    """Return the version from pyproject.toml in dev, else the installed package metadata.
+
+    The source checkout is authoritative when present (a stale dist in the dev
+    virtualenv must not shadow it); installed packages have no pyproject.toml
+    next to the source, so they fall through to importlib.metadata.
+    """
     try:
         pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
         with open(pyproject_path, "rb") as f:
             return tomllib.load(f)["project"]["version"]
     except Exception:
+        pass
+    try:
+        return _package_version("pr-generator-agent")
+    except PackageNotFoundError:
         return "unknown"
 
 


### PR DESCRIPTION
## Summary
The version resolution logic in `get_version()` now falls back to installed package metadata when `pyproject.toml` is not found, ensuring installed packages report a real version instead of "unknown".

## Changes
- Added a fallback to `importlib.metadata.version()` when `pyproject.toml` cannot be read.
- Documented the version resolution precedence (source checkout vs. installed package) in a docstring.

## Technical Details
- Uses `importlib.metadata.version("pr-generator-agent")` and catches `PackageNotFoundError`, returning `"unknown"` only if both lookups fail.