### PR TITLE
build(makefile): fix build target deleting venv via clean dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,10 +258,16 @@ graph TB
 ## Pull Request Process
 
 1. **Automated Checks**: All PRs must pass `make check`
-2. **Architecture Review**: Large changes need ADR validation
-3. **AI Agent PRs**: Include session context in PR description
-4. **Human Review**: Maintainer reviews within 3 business days
-5. **Merge**: Once approved and checks pass, we'll merge your contribution
+2. **Conventional PR Title**: The PR title must be a valid conventional commit
+   subject (`type(scope): description`). PRs are squash-merged and the title
+   becomes the commit subject on `main`, which is what Release Please reads to
+   build the changelog and pick the version bump.
+3. **Architecture Review**: Large changes need ADR validation
+4. **AI Agent PRs**: Include session context in PR description
+5. **Human Review**: Maintainer reviews within 3 business days
+6. **Merge**: Once approved and checks pass, we'll squash-merge your contribution.
+   Merge commits are disabled — they put both the branch commit and the merge
+   commit on `main`, which made Release Please emit every change twice.
 
 ## License
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install check clean build pr clean-pyc
+.PHONY: install check clean clean-dist build pr clean-pyc
 
 # Virtual environment settings
 VENV := .venv
@@ -45,14 +45,21 @@ check: format lint test
 	@echo "\nAll checks passed!"
 	@echo "Next step: Ready to commit your changes"
 
-clean:
-	@echo "Cleaning up build artifacts and virtual environment..."
-	rm -rf dist/ build/ *.egg-info .coverage htmlcov/ .pytest_cache/ $(VENV)
+clean-dist:
+	@echo "Cleaning build artifacts..."
+	rm -rf dist/ build/ *.egg-info
+
+clean: clean-dist
+	@echo "Cleaning up caches and virtual environment..."
+	rm -rf .coverage htmlcov/ .pytest_cache/ $(VENV)
 	find . -name '__pycache__' -type d -exec rm -rf {} +
 	@echo "\nNext step:"
 	@echo "Run 'deactivate' to ensure python is not running in the virtual environment"
 
-build: clean
+# Depends on clean-dist, not clean: clean removes $(VENV), which this recipe
+# then needs to activate.
+build: clean-dist
+	@test -x $(VENV)/bin/python || { echo "No virtualenv at $(VENV). Run 'make install' first."; exit 1; }
 	. $(VENV)/bin/activate && python -m build
 
 # GitHub PR target


### PR DESCRIPTION
## What

Two repo-hygiene fixes, neither of which ships in the wheel.

- `make build` depended on `clean`, which does `rm -rf … $(VENV)` — then the recipe ran `. $(VENV)/bin/activate && python -m build` against the virtualenv it had just deleted. Artifact cleanup is now a separate `clean-dist` target that `build` depends on, so the venv survives. `clean` still removes everything it did before, now by depending on `clean-dist`.
- Documents the switch to squash-merge in CONTRIBUTING, including the requirement that PR titles be valid conventional commit subjects.

## Why now

`make build` failed for anyone who ran it — the release workflow builds on a fresh runner with `python -m build` directly, so CI never exercised the broken path and it went unnoticed. Building 1.7.0 locally is what surfaced it.

The squash-merge change is the fix for duplicate changelog entries. Under merge commits, both the branch commit and the merge commit land on `main`, and Release Please attributes the change to each — so 1.7.0 and 1.6.1 both list their single change twice. Merge commits are now disabled on the repo; `squash_merge_commit_title` is pinned to `PR_TITLE` rather than `COMMIT_OR_PR_TITLE` so the subject on `main` is always the reviewed PR title, not a branch commit subject that varies with how many commits the PR happens to have.

Typed `build:` deliberately. Nothing here is packaged, so no version bump and no PyPI release — this should land on `main` without Release Please opening a release PR.

## Test plan

- `make build` — succeeds, produces both artifacts, and `.venv/bin/python` still present afterward (previously the recipe failed outright)
- `make check` — format, lint, 114 tests green
- `clean` verified to still remove `dist/`, `build/`, `*.egg-info`, caches, and `$(VENV)` via its `clean-dist` dependency
- This PR is itself the first squash-merge; the absence of a duplicate entry in the next changelog is the confirmation